### PR TITLE
Bring Repo to Working State

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ./
         with:
           precice-version: ${{ matrix.precice-version }}
-          build-tests: 'OFF'
+          build-tests: 'ON'
 
       - name: debug
         run: |
@@ -31,7 +31,7 @@ jobs:
           ls -la
           echo $PWD
 
-      # - name: Run tests
-      #   working-directory: build
-      #   run: |
-      #     ctest
+      - name: Run tests
+        working-directory: build
+        run: |
+          ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,9 @@ jobs:
           echo $PWD
           echo $LD_LIBRARY_PATH
           if [[ ${{ matrix.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "release=true >> $GITHUB_OUTPUT"
+            echo "release=true" >> $GITHUB_OUTPUT
           else
-            echo "release=false >> $GITHUB_OUTPUT"
+            echo "release=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Run tests if not release tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Run tests if not release tag
-        if: ${{ ! steps.debug.outputs.release }}
+        if: ${{ steps.debug.outputs.release }} == 'false'
         working-directory: precice/build
         run: |
           ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,3 +34,4 @@ jobs:
         working-directory: precice/build
         run: |
           ctest
+          make test_install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,6 @@ jobs:
           ls -la
           echo $PWD
           echo $LD_LIBRARY_PATH
-
-      - name: Check for release tag
-        run: |
           if [[ ${{ matrix.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=release::true"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,9 +40,14 @@ jobs:
           ls -la
           echo $PWD
           echo $LD_LIBRARY_PATH
+          if [[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::set-output name=release::true"
+          else
+            echo "::set-output name=release::false"
+          fi
 
       - name: Run tests if not release tag
-        if: '[[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]' == 'false'
+        if: ${{ ! steps.debug.outputs.release }}
         working-directory: precice/build
         run: |
           ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,12 +17,19 @@ jobs:
         run: |
           echo $GITHUB_WORKSPACE
           ls -la
+          echo $PWD
       
       - name: Set up preCICE
         uses: ./
         with:
           precice-version: ${{ matrix.precice-version }}
           build-tests: 'OFF'
+
+      - name: debug
+        run: |
+          echo $GITHUB_WORKSPACE
+          ls -la
+          echo $PWD
 
       # - name: Run tests
       #   working-directory: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
         precice-version: ['develop', 'main']
 
@@ -32,6 +31,6 @@ jobs:
           echo $PWD
 
       - name: Run tests
-        working-directory: build
+        working-directory: precice/build
         run: |
           ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,14 +5,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         precice-version: ['develop', 'master']
 
     steps:
-      - name: check out repository
+      - name: Check out repository
         uses: actions/checkout@v3
       
-      - name: set up precice
+      - name: Set up precice
         uses: ./
         with:
           precice-version: ${{ matrix.precice-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,13 +42,16 @@ jobs:
           echo $LD_LIBRARY_PATH
           if [[ ${{ matrix.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "release=true" >> $GITHUB_OUTPUT
+            echo "release=true"
           else
             echo "release=false" >> $GITHUB_OUTPUT
+            echo "release=false"
           fi
 
       - name: Run tests if not release tag
         if: steps.debug.outputs.release == 'false'
         working-directory: precice/build
         run: |
+          cat $GITHUB_OUTPUT
           ctest
           make test_install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         precice-version: ['develop', 'main']
 
@@ -29,6 +30,7 @@ jobs:
           echo $GITHUB_WORKSPACE
           ls -la
           echo $PWD
+          echo $LD_LIBRARY_PATH
 
       - name: Run tests
         working-directory: precice/build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: 'Test setup-precice-action'
-on: [push, pull_request]
+on: 
+  push:
+    - main
+  pull_request
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,14 @@
 name: 'Test setup-precice-action'
-on: 
+on:
   push:
-    - main
-  pull_request
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,9 +41,9 @@ jobs:
           echo $PWD
           echo $LD_LIBRARY_PATH
           if [[ ${{ matrix.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "::set-output name=release::true"
+            echo "release=true >> $GITHUB_OUTPUT"
           else
-            echo "::set-output name=release::false"
+            echo "release=false >> $GITHUB_OUTPUT"
           fi
 
       - name: Run tests if not release tag

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        precice-version: ['develop', 'main']
+        precice-version: ['develop', 'main', 'v2.5.0']
 
     steps:
       - name: Check out repository
@@ -41,7 +41,8 @@ jobs:
           echo $PWD
           echo $LD_LIBRARY_PATH
 
-      - name: Run tests
+      - name: Run tests if not release tag
+        if: '[[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]' == 'false'
         working-directory: precice/build
         run: |
           ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,19 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
+
+      - name: debug
+        run: |
+          echo $GITHUB_WORKSPACE
+          ls -la
       
-      - name: Set up precice
+      - name: Set up preCICE
         uses: ./
         with:
           precice-version: ${{ matrix.precice-version }}
+          build-tests: 'OFF'
+
+      # - name: Run tests
+      #   working-directory: build
+      #   run: |
+      #     ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,9 +47,8 @@ jobs:
           fi
 
       - name: Run tests if not release tag
-        if: ${{ ! steps.debug.outputs.release }}
+        if: steps.debug.outputs.release == 'false'
         working-directory: precice/build
         run: |
-          echo ${{ steps.debug.outputs.release }}
           ctest
           make test_install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,5 +50,6 @@ jobs:
         if: ${{ ! steps.debug.outputs.release }}
         working-directory: precice/build
         run: |
+          echo ${{ steps.debug.outputs.release }}
           ctest
           make test_install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: 'Test setup-precice-action'
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        precice-version: ['develop', 'master']
+
+    steps:
+      - name: check out repository
+        uses: actions/checkout@v3
+      
+      - name: set up precice
+        uses: ./
+        with:
+          precice-version: ${{ matrix.precice-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,5 @@ jobs:
         if: steps.debug.outputs.release == 'false'
         working-directory: precice/build
         run: |
-          cat $GITHUB_OUTPUT
           ctest
           make test_install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
           ls -la
           echo $PWD
           echo $LD_LIBRARY_PATH
+
+      - name: Check for release tag
+        run: |
           if [[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=release::true"
           else

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        precice-version: ['develop', 'master']
+        precice-version: ['develop', 'main']
 
     steps:
       - name: Check out repository

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
           fi
 
       - name: Run tests if not release tag
-        if: ${{ steps.debug.outputs.release }} == 'false'
+        if: ${{ ! steps.debug.outputs.release }}
         working-directory: precice/build
         run: |
           ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,8 @@ jobs:
           precice-version: ${{ matrix.precice-version }}
           build-tests: 'ON'
 
-      - name: debug
-        run: |
-          echo $GITHUB_WORKSPACE
-          ls -la
-          echo $PWD
-          echo $LD_LIBRARY_PATH
+      - name: Check release version
+        id: check-release
           if [[ ${{ matrix.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "release=true" >> $GITHUB_OUTPUT
             echo "release=true"
@@ -48,10 +44,18 @@ jobs:
             echo "release=false"
           fi
 
+      - name:
+        run: |
+          echo ${{ steps.check-release.outputs.release }}
+          echo $GITHUB_WORKSPACE
+          ls -la
+          echo $PWD
+          echo $LD_LIBRARY_PATH
+
+
       - name: Run tests if not release tag
-        if: steps.debug.outputs.release == 'false'
+        if: steps.check-release.outputs.release == 'false'
         working-directory: precice/build
         run: |
-          echo ${{ steps.debug.outputs.release }}
           ctest
           make test_install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
 
       - name: Check release version
         id: check-release
+        run: |
           if [[ ${{ matrix.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "release=true" >> $GITHUB_OUTPUT
             echo "release=true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,5 +52,6 @@ jobs:
         if: steps.debug.outputs.release == 'false'
         working-directory: precice/build
         run: |
+          echo ${{ steps.debug.outputs.release }}
           ctest
           make test_install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
             echo "release=false"
           fi
 
-      - name:
+      - name: debug
         run: |
           echo ${{ steps.check-release.outputs.release }}
           echo $GITHUB_WORKSPACE

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         precice-version: ['develop', 'main', 'v2.5.0']
 
@@ -43,7 +43,7 @@ jobs:
 
       - name: Check for release tag
         run: |
-          if [[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          if [[ ${{ matrix.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             echo "::set-output name=release::true"
           else
             echo "::set-output name=release::false"

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # setup-precice-action
+
+This action installs preCICE in the given prefix and adds it to the path.
+
+## Inputs
+
+### `precice-version`
+
+The version of preCICE to use. Can be a branch or tag or SHA. Defaults to `develop`
+
+### `install-prefix`
+
+The installation prefix for preCICE. Default is `/usr/local`
+
+### `build-tests`
+
+Whether to build tests. Should be `OFF` off for all non-develop builds. Defaults to `OFF`
+
+## Example usage
+
+```yml
+- name: build preCICE
+  uses: precice/setup-precice-action@main
+  with:
+    precice-version: develop
+    install-prefix: /usr/local
+```

--- a/action.yml
+++ b/action.yml
@@ -30,15 +30,18 @@ runs:
       run: |
         cmake --version
         cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF ..
+      shell: bash
 
     - name: Compile
       working-directory: build
       run: |
         make -j $(nproc)
+      shell: bash
 
     - name: Install
       working-directory: build
       run: make install
+      shell: bash
 
     - name: Add to path
       run: |
@@ -47,3 +50,4 @@ runs:
         export CPATH=$GITHUB_WORKSPACE/precice/include:$CPATH
         export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
         export CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,10 @@ runs:
       run: |
         sudo apt update
         sudo apt install -y wget
-        wget https://github.com/precice/precice/releases/download/${{ inputs.precice-version }}/libprecice2_${{ inputs.precice-version\#"v" }}_$(lsb_release -cs).deb
-        sudo apt install -y ./libprecice2_${{ inputs.precice-version\#"v" }}_$(lsb_release -cs).deb
-        rm libprecice2_${{ inputs.precice-version\#"v" }}_$(lsb_release -cs).deb
+        VERSION=${{ inputs.precice-version }}
+        wget https://github.com/precice/precice/releases/download/${VERSION}/libprecice2_${VERSION#v}_$(lsb_release -cs).deb
+        sudo apt install -y ./libprecice2_${VERSION#v}_$(lsb_release -cs).deb
+        rm libprecice2_${VERSION#v}_$(lsb_release -cs).deb
         exit 0
 
     - name: check out repository

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,9 @@ runs:
       run: |
         sudo apt update
         sudo apt install -y wget
-        wget https://github.com/precice/precice/releases/download/${{ inputs.precice-version }}/libprecice2_${{ inputs.precice-version#"v" }}_$(lsb_release -cs).deb
-        sudo apt install -y ./libprecice2_${{ inputs.precice-version#"v" }}_$(lsb_release -cs).deb
-        rm libprecice2_${{ inputs.precice-version#"v" }}_$(lsb_release -cs).deb
+        wget https://github.com/precice/precice/releases/download/${{ inputs.precice-version }}/libprecice2_${{ inputs.precice-version\#"v" }}_$(lsb_release -cs).deb
+        sudo apt install -y ./libprecice2_${{ inputs.precice-version\#"v" }}_$(lsb_release -cs).deb
+        rm libprecice2_${{ inputs.precice-version\#"v" }}_$(lsb_release -cs).deb
         exit 0
 
     - name: check out repository

--- a/action.yml
+++ b/action.yml
@@ -18,8 +18,8 @@ runs:
     
     - name: install dependencies
       run: |
-        apt update
-        apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
+        sudo apt update
+        sudo apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
       shell: bash
 
     - name: Generate build directory

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
   build-tests:
     required: false
     default: 'OFF'
-    description: 'Whether to build tests. Defaults to `OFF`'
+    description: 'Whether to build tests. Default is `OFF`'
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -45,10 +45,10 @@ runs:
       shell: bash
 
     - name: Add to path
-      run: |
-        export PATH=$GITHUB_WORKSPACE/precice/bin:$PATH
-        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH
-        export CPATH=$GITHUB_WORKSPACE/precice/include:$CPATH
-        export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
-        export CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH
+      env:
+        PATH: $GITHUB_WORKSPACE/precice/bin:$PATH
+        LD_LIBRARY_PATH: $GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH
+        CPATH: $GITHUB_WORKSPACE/precice/include:$CPATH
+        PKG_CONFIG_PATH: $GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
+        CMAKE_PREFIX_PATH: $GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,6 @@ inputs:
 
 runs:
   using: "composite"
-  shell: bash
   steps: 
     - name: check out repository
       uses: actions/checkout@v3
@@ -21,9 +20,10 @@ runs:
       run: |
         apt update
         apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
+      shell: bash
 
     - name: Generate build directory
-        run: mkdir -p build
+      run: mkdir -p build
 
     - name: Configure
       working-directory: build

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,9 @@ runs:
       shell: bash
       run: |
         if [[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "release=true >> $GITHUB_OUTPUT"
+          echo "release=true" >> $GITHUB_OUTPUT
         else
-          echo "release=false >> $GITHUB_OUTPUT"
+          echo "release=false" >> $GITHUB_OUTPUT
         fi
 
     - name: install prebuilt binaries

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Build preCICE'
-description: 'Installs preCICE in $HOME/precice and adds it to the path.'
+description: 'Installs preCICE in the given prefix and adds it to the path.'
 
 inputs:
   precice-version:
@@ -10,11 +10,15 @@ inputs:
     required: false
     default: 'OFF'
     description: 'Whether to build tests. Default is `OFF`'
+  install-prefix:
+    required: false
+    default: '/usr/local'
+    description: 'The installation prefix for preCICE. Default is `/usr/local`'
 
 runs:
   using: "composite"
   steps: 
-    - name: check out repository # clone to $HOME/precice
+    - name: check out repository
       uses: actions/checkout@v3
       with:
         repository: precice/precice
@@ -48,7 +52,7 @@ runs:
         GITHUB_WORKSPACE: $HOME
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=$HOME/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
+        cmake -DCMAKE_INSTALL_PREFIX=${{ inputs.install-prefix }} -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=${{ inputs.build-tests }} ..
 
     - name: Compile
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -28,25 +28,25 @@ runs:
       shell: bash
 
     - name: Generate build directory
-      working-directory: $GITHUB_WORKSPACE/precice/build
+      working-directory: precice
       run: mkdir -p build
       shell: bash
 
     - name: Configure
-      working-directory: $GITHUB_WORKSPACE/precice/build
+      working-directory: precice/build
       run: |
         cmake --version
         cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
       shell: bash
 
     - name: Compile
-      working-directory: $GITHUB_WORKSPACE/precice/build
+      working-directory: precice/build
       run: |
         make -j $(nproc)
       shell: bash
 
     - name: Install
-      working-directory: $GITHUB_WORKSPACE/precice/build
+      working-directory: precice/build
       run: make install
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -39,15 +39,22 @@ runs:
         wget https://github.com/precice/precice/releases/download/${VERSION}/libprecice2_${VERSION#v}_$(lsb_release -cs).deb
         sudo apt install -y ./libprecice2_${VERSION#v}_$(lsb_release -cs).deb
         rm libprecice2_${VERSION#v}_$(lsb_release -cs).deb
+    
+    - name: Get preCICE version hash
+      if: steps.check.outputs.release == 'false'
+      id: get-hash
+      shell: bash
+      run: |
+        echo "precice-hash=$(git ls-remote --exit-code --heads https://github.com/precice/precice.git ${{ inputs.precice-version }} | awk '{print $1}')" >> $GITHUB_OUTPUT
 
     - name: cache preCICE
       if: steps.check.outputs.release == 'false'
       uses: actions/cache@v3
       with:
         path: ${{ inputs.install-prefix }}
-        key: ${{ runner.os }}-precice-${{ inputs.precice-version }}
+        key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
         restore-keys: |
-          ${{ runner.os }}-precice-${{ inputs.precice-version }}
+          ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
 
     - name: check out repository
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
@@ -122,4 +129,4 @@ runs:
       uses: actions/cache/save@v3
       with:
         path: ${{ inputs.install-prefix }}
-        key: ${{ runner.os }}-precice-${{ inputs.precice-version }}
+        key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}

--- a/action.yml
+++ b/action.yml
@@ -40,6 +40,15 @@ runs:
         sudo apt install -y ./libprecice2_${VERSION#v}_$(lsb_release -cs).deb
         rm libprecice2_${VERSION#v}_$(lsb_release -cs).deb
 
+    - name: cache preCICE
+      if: steps.check.outputs.release == 'false'
+      uses: actions/cache@v3
+      with:
+        path: ${{ inputs.install-prefix }}
+        key: ${{ runner.os }}-precice-${{ inputs.precice-version }}
+        restore-keys: |
+          ${{ runner.os }}-precice-${{ inputs.precice-version }}
+
     - name: check out repository
       if: steps.check.outputs.release == 'false'
       uses: actions/checkout@v3

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,16 @@ runs:
         echo "PKG_CONFIG_PATH=$HOME/precice/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
         echo "CPATH=$HOME/precice/include:$CPATH" >> $GITHUB_ENV
         echo "CMAKE_PREFIX_PATH=$HOME/precice:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
-        ls $HOME/precice
+
+    - name: More debugging
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: |
+        ls -l $HOME/precice/
+        ls -l $HOME/precice/bin
+        ls -l $HOME/precice/lib
+        ls -l $HOME/precice/include
+        pkg-config --cflags --libs precice
 
     - name: cache preCICE
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,11 @@ runs:
         GITHUB_WORKSPACE: $HOME
       run: mkdir -p build
 
+    - name: Show preCICE state
+      shell: bash
+      working-directory: precice
+      run: git log -n 1
+
     - name: Configure
       shell: bash
       working-directory: precice/build

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Build preCICE'
-description: 'Installs preCICE in $GITHUB_WORKSPACE/precice and adds it to the path.'
+description: 'Installs preCICE in $HOME/precice and adds it to the path.'
 
 inputs:
   precice-version:
@@ -14,12 +14,14 @@ inputs:
 runs:
   using: "composite"
   steps: 
-    - name: check out repository
+    - name: check out repository # clone to $HOME/precice
       uses: actions/checkout@v3
       with:
         repository: precice/precice
         ref: ${{ inputs.precice-version }}
         path: precice
+      env: 
+        GITHUB_WORKSPACE: $HOME
     
     - name: install dependencies
       run: |
@@ -28,33 +30,33 @@ runs:
       shell: bash
 
     - name: Generate build directory
-      working-directory: precice
+      working-directory: $HOME/precice
       run: mkdir -p build
       shell: bash
 
     - name: Configure
-      working-directory: precice/build
+      working-directory: $HOME/precice/build
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
+        cmake -DCMAKE_INSTALL_PREFIX=$HOME/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
       shell: bash
 
     - name: Compile
-      working-directory: precice/build
+      working-directory: $HOME/precice/build
       run: |
         make -j $(nproc)
       shell: bash
 
     - name: Install
-      working-directory: precice/build
+      working-directory: $HOME/precice/build
       run: make install
       shell: bash
 
     - name: Add to path
       run: |
-        echo "PATH=$GITHUB_WORKSPACE/precice/bin:$PATH" >> $GITHUB_ENV
-        echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
-        echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
-        echo "CPATH=$GITHUB_WORKSPACE/precice/include:$CPATH" >> $GITHUB_ENV
-        echo "CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
+        echo "PATH=$HOME/precice/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$HOME/precice/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=$HOME/precice/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+        echo "CPATH=$HOME/precice/include:$CPATH" >> $GITHUB_ENV
+        echo "CMAKE_PREFIX_PATH=$HOME/precice:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -12,8 +12,8 @@ inputs:
     description: 'Whether to build tests. Default is `OFF`'
   install-prefix:
     required: false
-    default: '/usr/local'
-    description: 'The installation prefix for preCICE. Default is `/usr/local`'
+    default: '$HOME/precice'
+    description: 'The installation prefix for preCICE. Default is `$HOME/precice`'
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -45,10 +45,5 @@ runs:
       shell: bash
 
     - name: Add to path
-      env:
-        PATH: $GITHUB_WORKSPACE/precice/bin:$PATH
-        LD_LIBRARY_PATH: $GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH
-        CPATH: $GITHUB_WORKSPACE/precice/include:$CPATH
-        PKG_CONFIG_PATH: $GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
-        CMAKE_PREFIX_PATH: $GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH
+      run: export PATH=$GITHUB_WORKSPACE/precice/bin:$PATH
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -13,10 +13,6 @@ inputs:
 
 runs:
   using: "composite"
-  defaults:
-    run:
-      shell: bash
-
   steps: 
     - name: check out repository
       uses: actions/checkout@v3
@@ -29,25 +25,30 @@ runs:
       run: |
         sudo apt update
         sudo apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
+      shell: bash
 
     - name: Generate build directory
       working-directory: precice
       run: mkdir -p build
+      shell: bash
 
     - name: Configure
       working-directory: precice/build
       run: |
         cmake --version
         cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
+      shell: bash
 
     - name: Compile
       working-directory: precice/build
       run: |
         make -j $(nproc)
+      shell: bash
 
     - name: Install
       working-directory: precice/build
       run: make install
+      shell: bash
 
     - name: Add to path
       run: |
@@ -56,3 +57,4 @@ runs:
         echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
         echo "CPATH=$GITHUB_WORKSPACE/precice/include:$CPATH" >> $GITHUB_ENV
         echo "CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
+      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -123,6 +123,7 @@ runs:
         echo "PKG_CONFIG_PATH=$HOME/precice/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
         echo "CPATH=$HOME/precice/include:$CPATH" >> $GITHUB_ENV
         echo "CMAKE_PREFIX_PATH=$HOME/precice:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
+        ls $HOME/precice
 
     - name: cache preCICE
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,7 @@ inputs:
 
 runs:
   using: "composite"
+  shell: bash
   steps: 
     - name: check out repository
       uses: actions/checkout@v3
@@ -40,9 +41,9 @@ runs:
       run: make install
 
     - name: Add to path
-        run: |
-          export PATH=$GITHUB_WORKSPACE/precice/bin:$PATH
-          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH
-          export CPATH=$GITHUB_WORKSPACE/precice/include:$CPATH
-          export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
-          export CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH
+      run: |
+        export PATH=$GITHUB_WORKSPACE/precice/bin:$PATH
+        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH
+        export CPATH=$GITHUB_WORKSPACE/precice/include:$CPATH
+        export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
+        export CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH

--- a/action.yml
+++ b/action.yml
@@ -28,24 +28,25 @@ runs:
       shell: bash
 
     - name: Generate build directory
+      working-directory: $GITHUB_WORKSPACE/precice/build
       run: mkdir -p build
       shell: bash
 
     - name: Configure
-      working-directory: build
+      working-directory: $GITHUB_WORKSPACE/precice/build
       run: |
         cmake --version
         cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
       shell: bash
 
     - name: Compile
-      working-directory: build
+      working-directory: $GITHUB_WORKSPACE/precice/build
       run: |
         make -j $(nproc)
       shell: bash
 
     - name: Install
-      working-directory: build
+      working-directory: $GITHUB_WORKSPACE/precice/build
       run: make install
       shell: bash
 

--- a/action.yml
+++ b/action.yml
@@ -20,6 +20,7 @@ runs:
   steps: 
 
     - name: check for release # if the version is a release, install from prebuilt binaries
+      id: check
       shell: bash
       run: |
         if [[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/action.yml
+++ b/action.yml
@@ -39,9 +39,9 @@ runs:
         wget https://github.com/precice/precice/releases/download/${VERSION}/libprecice2_${VERSION#v}_$(lsb_release -cs).deb
         sudo apt install -y ./libprecice2_${VERSION#v}_$(lsb_release -cs).deb
         rm libprecice2_${VERSION#v}_$(lsb_release -cs).deb
-        exit 0
 
     - name: check out repository
+      if: steps.check.outputs.release == 'false'
       uses: actions/checkout@v3
       with:
         repository: precice/precice
@@ -51,12 +51,14 @@ runs:
         GITHUB_WORKSPACE: $HOME
     
     - name: install dependencies
+      if: steps.check.outputs.release == 'false'
       run: |
         sudo apt update
         sudo apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
       shell: bash
 
     - name: Generate build directory
+      if: steps.check.outputs.release == 'false'
       shell: bash
       working-directory: precice
       env: 
@@ -64,11 +66,13 @@ runs:
       run: mkdir -p build
 
     - name: Show preCICE state
+      if: steps.check.outputs.release == 'false'
       shell: bash
       working-directory: precice
       run: git log -n 1
 
     - name: Configure
+      if: steps.check.outputs.release == 'false'
       shell: bash
       working-directory: precice/build
       env:
@@ -78,6 +82,7 @@ runs:
         cmake -DCMAKE_INSTALL_PREFIX=${{ inputs.install-prefix }} -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=${{ inputs.build-tests }} ..
 
     - name: Compile
+      if: steps.check.outputs.release == 'false'
       shell: bash
       working-directory: precice/build
       env:
@@ -86,6 +91,7 @@ runs:
         make -j $(nproc)
 
     - name: Install
+      if: steps.check.outputs.release == 'false'
       shell: bash
       working-directory: precice/build
       env:
@@ -93,6 +99,7 @@ runs:
       run: make install
 
     - name: Add to path
+      if: steps.check.outputs.release == 'false'
       shell: bash
       run: |
         echo "PATH=$HOME/precice/bin:$PATH" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -35,9 +35,9 @@ runs:
       run: |
         sudo apt update
         sudo apt install -y wget
-        wget https://github.com/precice/precice/releases/download/${{ inputs.precice-version }}/libprecice2_${{ inputs.precice-version#v }}_$(lsb_release -cs).deb
+        wget https://github.com/precice/precice/releases/download/${{ inputs.precice-version }}/libprecice2_${{ inputs.precice-version#"v" }}_$(lsb_release -cs).deb
         sudo apt install -y ./libprecice2_${{ inputs.precice-version#"v" }}_$(lsb_release -cs).deb
-        rm libprecice2_${{ inputs.precice-version#v }}_$(lsb_release -cs).deb
+        rm libprecice2_${{ inputs.precice-version#"v" }}_$(lsb_release -cs).deb
         exit 0
 
     - name: check out repository

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'Whether to build tests. Default is `OFF`'
   install-prefix:
     required: false
-    default: '${{ env.HOME }}/precice'
+    default: '$HOME/precice'
     description: 'The installation prefix for preCICE. Default is `$HOME/precice`'
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -34,7 +34,7 @@ runs:
       working-directory: build
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD-TESTING=${{ inputs.build-tests }} ..
+        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
       shell: bash
 
     - name: Compile
@@ -49,5 +49,10 @@ runs:
       shell: bash
 
     - name: Add to path
-      run: export PATH=$GITHUB_WORKSPACE/precice/bin:$PATH
+      run: |
+        export PATH=$GITHUB_WORKSPACE/precice/bin:$PATH
+        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH
+        export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
+        export CPATH=$PRECICE_PREFIX/include:$CPATH
+        export CMAKE_PREFIX_PATH=$PRECICE_PREFIX:$CMAKE_PREFIX_PATH
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -24,9 +24,9 @@ runs:
       shell: bash
       run: |
         if [[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-          echo "::set-output name=release::true"
+          echo "release=true >> $GITHUB_OUTPUT"
         else
-          echo "::set-output name=release::false"
+          echo "release=false >> $GITHUB_OUTPUT"
         fi
 
     - name: install prebuilt binaries

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ inputs:
     description: 'Whether to build tests. Default is `OFF`'
   install-prefix:
     required: false
-    default: '$HOME/precice'
+    default: '${{ env.HOME }}/precice'
     description: 'The installation prefix for preCICE. Default is `$HOME/precice`'
 
 runs:

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,15 @@ runs:
         key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
         restore-keys: |
           ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
+    
+    - name: debug
+      if: steps.check.outputs.release == 'false'
+      shell: bash
+      run: |
+        echo "cache-hit=${{ steps.cache.outputs.cache-hit }}"
+        echo "precice-hash=${{ steps.get-hash.outputs.precice-hash }}"
+        echo "precice-version=${{ inputs.precice-version }}"
+        echo "install-prefix=${{ inputs.install-prefix }}"
 
     - name: check out repository
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,10 @@ inputs:
 
 runs:
   using: "composite"
+  defaults:
+    run:
+      shell: bash
+
   steps: 
     - name: check out repository
       uses: actions/checkout@v3
@@ -25,36 +29,30 @@ runs:
       run: |
         sudo apt update
         sudo apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
-      shell: bash
 
     - name: Generate build directory
       working-directory: precice
       run: mkdir -p build
-      shell: bash
 
     - name: Configure
       working-directory: precice/build
       run: |
         cmake --version
         cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
-      shell: bash
 
     - name: Compile
       working-directory: precice/build
       run: |
         make -j $(nproc)
-      shell: bash
 
     - name: Install
       working-directory: precice/build
       run: make install
-      shell: bash
 
     - name: Add to path
       run: |
-        echo "$GITHUB_WORKSPACE/precice/bin" >> $GITHUB_PATH
-        echo "$GITHUB_WORKSPACE/precice/lib" >> $GITHUB_PATH
-        echo "$GITHUB_WORKSPACE/precice/lib/pkgconfig" >> $GITHUB_PATH
-        echo "$GITHUB_WORKSPACE/precice/include" >> $GITHUB_PATH
-        echo "$GITHUB_WORKSPACE/precice" >> $GITHUB_PATH
-      shell: bash
+        echo "PATH=$GITHUB_WORKSPACE/precice/bin:$PATH" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
+        echo "PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
+        echo "CPATH=$GITHUB_WORKSPACE/precice/include:$CPATH" >> $GITHUB_ENV
+        echo "CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,10 @@ runs:
         echo "precice-hash=$(git ls-remote --exit-code --heads https://github.com/precice/precice.git ${{ inputs.precice-version }} | awk '{print $1}')" >> $GITHUB_OUTPUT
 
     - name: cache preCICE
-      id: cache
       if: steps.check.outputs.release == 'false'
       uses: actions/cache@v3
       with:
-        path: ${{ inputs.install-prefix }}
+        path: /home/runner/precice
         key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
         restore-keys: |
           ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
@@ -115,7 +114,14 @@ runs:
         GITHUB_WORKSPACE: $HOME
       run: |
         make -j $(nproc)
-        make install
+
+    - name: Install
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: precice/build
+      env:
+        GITHUB_WORKSPACE: $HOME
+      run: make install
 
     - name: Add to path
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
@@ -137,5 +143,5 @@ runs:
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
-        path: ${{ inputs.install-prefix }}
+        path: /home/runner/precice
         key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}

--- a/action.yml
+++ b/action.yml
@@ -30,33 +30,41 @@ runs:
       shell: bash
 
     - name: Generate build directory
-      working-directory: $HOME/precice
-      run: mkdir -p build
       shell: bash
+      working-directory: precice
+      env: 
+        GITHUB_WORKSPACE: $HOME
+      run: mkdir -p build
 
     - name: Configure
-      working-directory: $HOME/precice/build
+      shell: bash
+      working-directory: precice/build
+      env:
+        GITHUB_WORKSPACE: $HOME
       run: |
         cmake --version
         cmake -DCMAKE_INSTALL_PREFIX=$HOME/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD_TESTING=${{ inputs.build-tests }} ..
-      shell: bash
 
     - name: Compile
-      working-directory: $HOME/precice/build
+      shell: bash
+      working-directory: precice/build
+      env:
+        GITHUB_WORKSPACE: $HOME
       run: |
         make -j $(nproc)
-      shell: bash
 
     - name: Install
-      working-directory: $HOME/precice/build
-      run: make install
       shell: bash
+      working-directory: precice/build
+      env:
+        GITHUB_WORKSPACE: $HOME
+      run: make install
 
     - name: Add to path
+      shell: bash
       run: |
         echo "PATH=$HOME/precice/bin:$PATH" >> $GITHUB_ENV
         echo "LD_LIBRARY_PATH=$HOME/precice/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
         echo "PKG_CONFIG_PATH=$HOME/precice/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
         echo "CPATH=$HOME/precice/include:$CPATH" >> $GITHUB_ENV
         echo "CMAKE_PREFIX_PATH=$HOME/precice:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
-      shell: bash

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ runs:
         sudo apt update
         sudo apt install -y wget
         wget https://github.com/precice/precice/releases/download/${{ inputs.precice-version }}/libprecice2_${{ inputs.precice-version#v }}_$(lsb_release -cs).deb
-        sudo apt install -y ./libprecice2_${{ inputs.precice-version#v }}_$(lsb_release -cs).deb
+        sudo apt install -y ./libprecice2_${{ inputs.precice-version#"v" }}_$(lsb_release -cs).deb
         rm libprecice2_${{ inputs.precice-version#v }}_$(lsb_release -cs).deb
         exit 0
 

--- a/action.yml
+++ b/action.yml
@@ -116,3 +116,10 @@ runs:
         echo "PKG_CONFIG_PATH=$HOME/precice/lib/pkgconfig:$PKG_CONFIG_PATH" >> $GITHUB_ENV
         echo "CPATH=$HOME/precice/include:$CPATH" >> $GITHUB_ENV
         echo "CMAKE_PREFIX_PATH=$HOME/precice:$CMAKE_PREFIX_PATH" >> $GITHUB_ENV
+
+    - name: cache preCICE
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
+      uses: actions/cache/save@v3
+      with:
+        path: ${{ inputs.install-prefix }}
+        key: ${{ runner.os }}-precice-${{ inputs.precice-version }}

--- a/action.yml
+++ b/action.yml
@@ -17,9 +17,9 @@ runs:
         ref: ${{ inputs.precice-version }}
     
     - name: install dependencies
-        run: |
-            apt update
-            apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
+      run: |
+        apt update
+        apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
 
     - name: Generate build directory
         run: mkdir -p build
@@ -41,8 +41,8 @@ runs:
 
     - name: Add to path
         run: |
-          echo "$GITHUB_WORKSPACE/precice/bin" >> $PATH
-          echo "$GITHUB_WORKSPACE/precice/lib" >> $LD_LIBRARY_PATH
-          echo "$GITHUB_WORKSPACE/precice/include" >> $CPATH
-          echo "$GITHUB_WORKSPACE/precice/lib/pkgconfig" >> $PKG_CONFIG_PATH
-          echo "$GITHUB_WORKSPACE/precice" >> $CMAKE_PREFIX_PATH
+          export PATH=$GITHUB_WORKSPACE/precice/bin:$PATH
+          export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH
+          export CPATH=$GITHUB_WORKSPACE/precice/include:$CPATH
+          export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
+          export CMAKE_PREFIX_PATH=$GITHUB_WORKSPACE/precice:$CMAKE_PREFIX_PATH

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,7 @@ runs:
 
     - name: Generate build directory
       run: mkdir -p build
+      shell: bash
 
     - name: Configure
       working-directory: build

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     required: true
     default: 'develop'
     description: 'The version of preCICE to use. Can be a branch or tag or SHA. Defaults to `develop`'
+  build-tests:
+    required: false
+    default: 'OFF'
+    description: 'Whether to build tests. Defaults to `OFF`'
 
 runs:
   using: "composite"
@@ -30,7 +34,7 @@ runs:
       working-directory: build
       run: |
         cmake --version
-        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF ..
+        cmake -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/precice -DCMAKE_BUILD_TYPE=Release -DPRECICE_PETScMapping=OFF -DPRECICE_Python_Actions=OFF -DBUILD-TESTING=${{ inputs.build-tests }} ..
       shell: bash
 
     - name: Compile

--- a/action.yml
+++ b/action.yml
@@ -48,10 +48,11 @@ runs:
         echo "precice-hash=$(git ls-remote --exit-code --heads https://github.com/precice/precice.git ${{ inputs.precice-version }} | awk '{print $1}')" >> $GITHUB_OUTPUT
 
     - name: cache preCICE
+      id: cache
       if: steps.check.outputs.release == 'false'
       uses: actions/cache@v3
       with:
-        path: /home/runner/precice
+        path: ${{ inputs.install-prefix }}
         key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
         restore-keys: |
           ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
@@ -114,14 +115,7 @@ runs:
         GITHUB_WORKSPACE: $HOME
       run: |
         make -j $(nproc)
-
-    - name: Install
-      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
-      shell: bash
-      working-directory: precice/build
-      env:
-        GITHUB_WORKSPACE: $HOME
-      run: make install
+        make install
 
     - name: Add to path
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
@@ -143,5 +137,5 @@ runs:
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
-        path: /home/runner/precice
+        path: ${{ inputs.install-prefix }}
         key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}

--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,7 @@ runs:
           ${{ runner.os }}-precice-${{ inputs.precice-version }}
 
     - name: check out repository
-      if: steps.check.outputs.release == 'false'
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       uses: actions/checkout@v3
       with:
         repository: precice/precice
@@ -60,14 +60,14 @@ runs:
         GITHUB_WORKSPACE: $HOME
     
     - name: install dependencies
-      if: steps.check.outputs.release == 'false'
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       run: |
         sudo apt update
         sudo apt install -y build-essential cmake libeigen3-dev libxml2-dev libboost-all-dev petsc-dev python3-dev python3-numpy
       shell: bash
 
     - name: Generate build directory
-      if: steps.check.outputs.release == 'false'
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: precice
       env: 
@@ -75,13 +75,13 @@ runs:
       run: mkdir -p build
 
     - name: Show preCICE state
-      if: steps.check.outputs.release == 'false'
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: precice
       run: git log -n 1
 
     - name: Configure
-      if: steps.check.outputs.release == 'false'
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: precice/build
       env:
@@ -91,7 +91,7 @@ runs:
         cmake -DCMAKE_INSTALL_PREFIX=${{ inputs.install-prefix }} -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=${{ inputs.build-tests }} ..
 
     - name: Compile
-      if: steps.check.outputs.release == 'false'
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: precice/build
       env:
@@ -100,7 +100,7 @@ runs:
         make -j $(nproc)
 
     - name: Install
-      if: steps.check.outputs.release == 'false'
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       working-directory: precice/build
       env:
@@ -108,7 +108,7 @@ runs:
       run: make install
 
     - name: Add to path
-      if: steps.check.outputs.release == 'false'
+      if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       shell: bash
       run: |
         echo "PATH=$HOME/precice/bin:$PATH" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Build preCICE'
-description: 'Installs preCICE in  and adds it to the path.'
+description: 'Installs preCICE in $GITHUB_WORKSPACE/precice and adds it to the path.'
 
 inputs:
   precice-version:

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
 name: 'Build preCICE'
-description: 'Installs preCICE and adds it to the path. Ends in `$GITHUB_WORKSPACE/precice`'
+description: 'Installs preCICE in  and adds it to the path.'
 
 inputs:
   precice-version:
@@ -19,6 +19,7 @@ runs:
       with:
         repository: precice/precice
         ref: ${{ inputs.precice-version }}
+        path: precice
     
     - name: install dependencies
       run: |

--- a/action.yml
+++ b/action.yml
@@ -51,7 +51,7 @@ runs:
       if: steps.check.outputs.release == 'false'
       uses: actions/cache@v3
       with:
-        path: ${{ inputs.install-prefix }}
+        path: /home/runner/precice
         key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
         restore-keys: |
           ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}
@@ -134,5 +134,5 @@ runs:
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'
       uses: actions/cache/save@v3
       with:
-        path: ${{ inputs.install-prefix }}
+        path: /home/runner/precice
         key: ${{ runner.os }}-precice-${{ steps.get-hash.outputs.precice-hash }}

--- a/action.yml
+++ b/action.yml
@@ -52,9 +52,9 @@ runs:
 
     - name: Add to path
       run: |
-        export PATH=$GITHUB_WORKSPACE/precice/bin:$PATH
-        export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/precice/lib:$LD_LIBRARY_PATH
-        export PKG_CONFIG_PATH=$GITHUB_WORKSPACE/precice/lib/pkgconfig:$PKG_CONFIG_PATH
-        export CPATH=$PRECICE_PREFIX/include:$CPATH
-        export CMAKE_PREFIX_PATH=$PRECICE_PREFIX:$CMAKE_PREFIX_PATH
+        echo "$GITHUB_WORKSPACE/precice/bin" >> $GITHUB_PATH
+        echo "$GITHUB_WORKSPACE/precice/lib" >> $GITHUB_PATH
+        echo "$GITHUB_WORKSPACE/precice/lib/pkgconfig" >> $GITHUB_PATH
+        echo "$GITHUB_WORKSPACE/precice/include" >> $GITHUB_PATH
+        echo "$GITHUB_WORKSPACE/precice" >> $GITHUB_PATH
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,6 @@ runs:
   steps: 
 
     - name: check for release # if the version is a release, install from prebuilt binaries
-      id: check
       shell: bash
       run: |
         if [[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then

--- a/action.yml
+++ b/action.yml
@@ -129,10 +129,6 @@ runs:
       shell: bash
       run: |
         ls -l $HOME/precice/
-        ls -l $HOME/precice/bin
-        ls -l $HOME/precice/lib
-        ls -l $HOME/precice/include
-        pkg-config --cflags --libs precice
 
     - name: cache preCICE
       if: steps.check.outputs.release == 'false' && steps.cache.outputs.cache-hit != 'true'

--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,28 @@ inputs:
 runs:
   using: "composite"
   steps: 
+
+    - name: check for release # if the version is a release, install from prebuilt binaries
+      id: check
+      shell: bash
+      run: |
+        if [[ ${{ inputs.precice-version }} =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+          echo "::set-output name=release::true"
+        else
+          echo "::set-output name=release::false"
+        fi
+
+    - name: install prebuilt binaries
+      if: steps.check.outputs.release == 'true'
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y wget
+        wget https://github.com/precice/precice/releases/download/${{ inputs.precice-version }}/libprecice2_${{ inputs.precice-version#v }}_$(lsb_release -cs).deb
+        sudo apt install -y ./libprecice2_${{ inputs.precice-version#v }}_$(lsb_release -cs).deb
+        rm libprecice2_${{ inputs.precice-version#v }}_$(lsb_release -cs).deb
+        exit 0
+
     - name: check out repository
       uses: actions/checkout@v3
       with:


### PR DESCRIPTION
Brings this repo to a working state and adds a test for if the actions works.

To explain the layout of this repo, we have the main action `action.yml` that is called, when calling 
```yml
- name: example
  uses: precice/setup-precice-action@testing
```
in a workflow in a different repository. In this action we create a composite action, that clones precice/precice, installs the dependencies, and builds preCICE. Afterwards, the install directory is added to the path.
There are two options for this composite action. 
1. `precice-version`: This is the version or branch that is passed along to `actions/checkout` as [`ref`](https://github.com/actions/checkout#usage). Meaning, we can build `develop` as well as `main` or any tag using this workflow.
2. `build-tests`: This is mainly for the second file created in this PR. This is passed to the cmake config as the [`-DBUILD_TESTING`](https://precice.org/installation-source-configuration.html#options) flag. For an application of the workflow, building the tests would be unnecessary in my opinion, but for the test workflow is may be a good idea to check if the compilation is successful. 

This PR also creates a test used here to test if the main action is working as intended. It basically checks out this repo and uses the `action.yml` from the current branch with 
```yml
- name: Set up preCICE
  uses: ./
```
This executes every command from the `action.yml` and afterwards runs the installation tests.