### PR TITLE
Fix default prefix docs and recommendation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The version of preCICE to use. Can be a branch or tag or SHA. Defaults to `devel
 
 ### `install-prefix`
 
-The installation prefix for preCICE. Default is `/usr/local`
+The installation prefix for preCICE. Default is `$HOME/precice`
 
 ### `build-tests`
 
@@ -23,5 +23,4 @@ Whether to build tests. Should be `OFF` off for all non-develop builds. Defaults
   uses: precice/setup-precice-action@main
   with:
     precice-version: develop
-    install-prefix: /usr/local
 ```


### PR DESCRIPTION
Related to https://github.com/precice/setup-precice-action/issues/3

Following the default from https://github.com/precice/setup-precice-action/blob/94df8a6091dc03b1c4405c35119ca6f6721ecab6/action.yml#L15C15-L15C28

I am not sure what to set the recommendation to, but we should at least not recommend a system path till #3 is fixed.